### PR TITLE
fix: Dynamically setting the tablegpt ipykernel profile dir

### DIFF
--- a/src/tablegpt/__init__.py
+++ b/src/tablegpt/__init__.py
@@ -1,4 +1,33 @@
-import os
 import sys
+import warnings
+from pathlib import Path
 
-DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR = os.path.join(sys.prefix, "share/ipykernel/profile/tablegpt")
+possible_installation_locations = filter(lambda x: "site-packages" in x, sys.path)
+
+
+def _find_tablegpt_ipykernel_profile_dir(path):
+    possible_installation_location = Path(path).parents[2]
+    possible_profile_dir = Path(possible_installation_location, "share", "ipykernel", "profile", "tablegpt")
+
+    _startup_folder = Path(possible_profile_dir, "startup")
+
+    if next(_startup_folder.glob(r"*.py")):
+        return str(possible_profile_dir)
+
+    return
+
+
+try:
+    DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR = next(
+        map(
+            _find_tablegpt_ipykernel_profile_dir,
+            possible_installation_locations,
+        )
+    )
+except StopIteration:
+    # Means not found.
+    msg = """Unable to find tablegpt ipykernel. If you need to use a local kernel,
+please use `pip install -U tablegpt-agent[local]` to install the necessary dependencies.
+For more issues, please submit an issue to us https://github.com/tablegpt/tablegpt-agent/issues."""
+    warnings.warn(msg, stacklevel=2)
+    DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR = None


### PR DESCRIPTION
Sometimes, pip fails to install packages in the correct path matching `sys.prefix`, possibly due to insufficient permissions or other issues.

This PR dynamically updates the DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR setting based on the user’s installation directory.

This helps prevent errors such as built-in function calls (e.g., read_df) not being found.