### PR TITLE
fix: make filename fields consistent

### DIFF
--- a/src/tablegpt/retriever/__init__.py
+++ b/src/tablegpt/retriever/__init__.py
@@ -25,7 +25,7 @@ def format_columns(
         return ""
     tables: dict = {}
     for doc in docs:
-        tables.setdefault(doc.metadata["file_name"], []).append(doc)
+        tables.setdefault(doc.metadata["filename"], []).append(doc)
 
     cols = []
     for table, t_docs in tables.items():

--- a/src/tablegpt/retriever/compressor.py
+++ b/src/tablegpt/retriever/compressor.py
@@ -43,7 +43,7 @@ class ColumnDocCompressor(BaseDocumentCompressor):
         cols = defaultdict(lambda: Document(page_content="", metadata={}))
 
         for doc in documents:
-            key = f"{doc.metadata['file_name']}:{doc.metadata['column']}"
+            key = f"{doc.metadata['filename']}:{doc.metadata['column']}"
 
             # Initialize if key is encountered first time
             if not cols[key].page_content:

--- a/tests/retriever/test_compressor.py
+++ b/tests/retriever/test_compressor.py
@@ -12,18 +12,18 @@ class TestCompressDocuments(unittest.TestCase):
         documents = [
             Document(
                 page_content="cell content",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
             ),
             Document(
                 page_content="cell content",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 2},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 2},
             ),
         ]
 
         expected_output = [
             Document(
                 page_content="column: A",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1, 2]},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1, 2]},
             )
         ]
 
@@ -34,22 +34,22 @@ class TestCompressDocuments(unittest.TestCase):
         documents = [
             Document(
                 page_content="A:1",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
             ),
             Document(
                 page_content="B:hello",
-                metadata={"file_name": "file1", "column": "B", "dtype": "str", "n_unique": 3, "value": "hello"},
+                metadata={"filename": "file1", "column": "B", "dtype": "str", "n_unique": 3, "value": "hello"},
             ),
         ]
 
         expected_output = [
             Document(
                 page_content="column: A",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1]},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1]},
             ),
             Document(
                 page_content="column: B",
-                metadata={"file_name": "file1", "column": "B", "dtype": "str", "n_unique": 3, "values": ["hello"]},
+                metadata={"filename": "file1", "column": "B", "dtype": "str", "n_unique": 3, "values": ["hello"]},
             ),
         ]
 
@@ -60,30 +60,30 @@ class TestCompressDocuments(unittest.TestCase):
         documents = [
             Document(
                 page_content="cell content",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "value": 1},
             ),
             Document(
                 page_content="cell content",
-                metadata={"file_name": "file2", "column": "A", "dtype": "int", "n_unique": 4, "value": 2},
+                metadata={"filename": "file2", "column": "A", "dtype": "int", "n_unique": 4, "value": 2},
             ),
             Document(
                 page_content="cell content",
-                metadata={"file_name": "file2", "column": "B", "dtype": "str", "n_unique": 3, "value": "world"},
+                metadata={"filename": "file2", "column": "B", "dtype": "str", "n_unique": 3, "value": "world"},
             ),
         ]
 
         expected_output = [
             Document(
                 page_content="column: A",
-                metadata={"file_name": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1]},
+                metadata={"filename": "file1", "column": "A", "dtype": "int", "n_unique": 5, "values": [1]},
             ),
             Document(
                 page_content="column: A",
-                metadata={"file_name": "file2", "column": "A", "dtype": "int", "n_unique": 4, "values": [2]},
+                metadata={"filename": "file2", "column": "A", "dtype": "int", "n_unique": 4, "values": [2]},
             ),
             Document(
                 page_content="column: B",
-                metadata={"file_name": "file2", "column": "B", "dtype": "str", "n_unique": 3, "values": ["world"]},
+                metadata={"filename": "file2", "column": "B", "dtype": "str", "n_unique": 3, "values": ["world"]},
             ),
         ]
 

--- a/tests/retriever/test_format.py
+++ b/tests/retriever/test_format.py
@@ -14,7 +14,7 @@ class TestFormatColumns(unittest.TestCase):
             Document(
                 page_content="column:Sex",
                 metadata={
-                    "file_name": "foo.csv",
+                    "filename": "foo.csv",
                     "column": "Sex",
                     "dtype": "string",
                     "n_unique": 2,
@@ -35,7 +35,7 @@ Here are some extra column information that might help you understand the datase
             Document(
                 page_content="column:Sex",
                 metadata={
-                    "file_name": "foo.csv",
+                    "filename": "foo.csv",
                     "column": "Sex",
                     "dtype": "string",
                     "n_unique": 3,


### PR DESCRIPTION
When use `CSVLoader` loads CSV or Excel files into Documents, fields is `filename`:

```python
if isinstance(self.file_path, Path):
    self.extra_metadata["filename"] = self.file_path.name
else:
    self.extra_metadata["filename"] = self.file_path
```