### PR TITLE
chore(agent-eval): fix `MemorySaver` version compatibility issue

### DIFF
--- a/realtabbench/agent_eval/requirements.txt
+++ b/realtabbench/agent_eval/requirements.txt
@@ -7,3 +7,5 @@ python-dotenv
 pyyaml
 ipython
 ipykernel
+# `MemorySaver` can dynamically manage the `Context Manager` starting from version 2.0.5
+langgraph-checkpoint>=2.0.5

--- a/realtabbench/agent_eval/student.py
+++ b/realtabbench/agent_eval/student.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 from uuid import uuid4
 
 from agent_eval.student_config import Settings
@@ -12,7 +12,6 @@ from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 from pybox import LocalPyBoxManager
 from pybox.kube import KubePyBoxManager
-from pydantic import BaseModel
 from tablegpt.agent import create_tablegpt_graph
 from tablegpt.agent.file_reading import Stage
 
@@ -49,7 +48,7 @@ normalize_llm = ChatOpenAI(**settings.normalize_llm) if settings.normalize_llm i
 
 # TODO: a copy-paste from tablegpt-chat
 # We need to refactor this and push it down to tablegpt-agent
-class Attachment(BaseModel):
+class Attachment(TypedDict):
     filename: str
     mimetype: str
     size: int = 0
@@ -109,7 +108,6 @@ async def create_student_graph(
         vlm=vlm,
         session_id=session_id,
         checkpointer=checkpointer,
-        model_type=model_type,
         normalize_llm=normalize_llm,
         error_trace_cleanup=settings.error_trace_cleanup,
     ).with_config(


### PR DESCRIPTION
After `langgraph-checkpoint>=2.0.5`, `MemorySaver` introduced `ExitStack` to dynamically manage contexts. However, using the with keyword does not work as expected.

In `MemorySaver`, the` __enter__ `method returns an `ExitStack` object, and `ExitStack` does not have a `get_next_version` method.

```python
def __enter__(self) -> "MemorySaver":
        return self.stack.__enter__()
```

This leads to an error when calling `graph.invoke`, error message: "AttributeError: 'ExitStack' object has no attribute 'get_next_version'".

```python
# AsyncPregelLoop
self.checkpointer_get_next_version = checkpointer.get_next_version
```