### PR TITLE
fix: use the built-in `site` package  to get  the correct path `site-packages` directory

### DIFF
--- a/src/tablegpt/__init__.py
+++ b/src/tablegpt/__init__.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import sys
+import site
 import warnings
 from pathlib import Path
-
-possible_installation_locations = filter(lambda x: "site-packages" in x, sys.path)
 
 
 def _find_tablegpt_ipykernel_profile_dir(path):
@@ -16,12 +14,14 @@ def _find_tablegpt_ipykernel_profile_dir(path):
         if next(_startup_folder.glob(r"*-udfs.py")):
             return str(possible_profile_dir)
     except StopIteration:
-        return None
+        return
 
 
 try:
     DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR: str | None = next(
-        filter(_find_tablegpt_ipykernel_profile_dir, possible_installation_locations)
+        path
+        for path in map(_find_tablegpt_ipykernel_profile_dir, [*site.getsitepackages(), site.getusersitepackages()])
+        if path is not None
     )
 
 except StopIteration:

--- a/tests/test_profile_init.py
+++ b/tests/test_profile_init.py
@@ -1,36 +1,69 @@
-import contextlib
+import sys
 import unittest
-from unittest.mock import patch
-
-from tablegpt import _find_tablegpt_ipykernel_profile_dir, possible_installation_locations
+from unittest.mock import MagicMock, patch
 
 
 class TestTableGPTInit(unittest.TestCase):
-    @patch("tablegpt.Path.glob")
-    def test_find_tablegpt_ipykernel_profile_dir_found(self, mock_glob):
-        mock_glob.return_value = iter(["mock-udfs.py"])
-        result = _find_tablegpt_ipykernel_profile_dir("/mock/path/to/site-packages")
-        assert result == "/mock/share/ipykernel/profile/tablegpt"
+    def setUp(self):
+        # Save the original tablegpt module if it exists
+        self.original_tablegpt = sys.modules.get("tablegpt")
 
-    @patch("tablegpt.Path.glob")
-    def test_default_tablegpt_ipykernel_profile_dir_found(self, mock_glob):
-        mock_glob.side_effect = [iter([]), iter(["mock-udfs.py"]), iter([])]
-        with (
-            patch("sys.path", ["/wrong/path/to/site-packages", "/mock/path/to/site-packages", "/another/wrong/path"]),
-            contextlib.suppress(StopIteration),
-        ):
-            result = next(filter(_find_tablegpt_ipykernel_profile_dir, possible_installation_locations))
-            assert result == "/mock/share/ipykernel/profile/tablegpt"
+        # Clear tablegpt from sys.modules
+        if "tablegpt" in sys.modules:
+            del sys.modules["tablegpt"]
 
-    @patch("tablegpt.Path.glob")
-    def test_default_tablegpt_ipykernel_profile_dir_not_found(self, mock_glob):
-        mock_glob.side_effect = [iter([]), iter([]), iter([])]
-        with (
-            patch("sys.path", ["/wrong/path/to/site-packages", "/another/wrong/path"]),
-            contextlib.suppress(StopIteration),
-        ):
-            result = next(filter(_find_tablegpt_ipykernel_profile_dir, possible_installation_locations))
-            assert result is None
+        # Create a mock site module
+        self.mock_site = MagicMock()
+        self.original_site = sys.modules["site"]
+        sys.modules["site"] = self.mock_site
+
+    def tearDown(self):
+        # Restore the original modules
+        sys.modules["site"] = self.original_site
+
+        # Restore the original tablegpt module if it existed
+        if self.original_tablegpt:
+            sys.modules["tablegpt"] = self.original_tablegpt
+        elif "tablegpt" in sys.modules:
+            del sys.modules["tablegpt"]
+
+    def test_find_tablegpt_ipykernel_profile_dir_found(self):
+        # mock return values
+        self.mock_site.getsitepackages.return_value = ["/usr/local/lib/python3.x/site-packages"]
+        self.mock_site.getusersitepackages.return_value = ""
+
+        with patch("pathlib.Path.glob", return_value=iter(["mock-udfs.py"])):
+            from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
+
+            assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR == "/usr/local/share/ipykernel/profile/tablegpt"
+
+    def test_default_tablegpt_ipykernel_profile_dir_found_second_path(self):
+        # mock return values
+        self.mock_site.getsitepackages.return_value = [
+            "/wrong/lib/python3.x/site-packages",
+            "/usr/local/lib/python3.x/site-packages",
+        ]
+        self.mock_site.getusersitepackages.return_value = "/home/user/.local/lib/python3.x/site-packages"
+
+        # Found in the second possible path.
+        with patch("pathlib.Path.glob", side_effect=[iter([]), iter(["mock-udfs.py"]), iter([])]):
+            from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
+
+            assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR == "/usr/local/share/ipykernel/profile/tablegpt"
+
+    def test_default_tablegpt_ipykernel_profile_dir_not_found(self):
+        # mock return values
+        self.mock_site.getsitepackages.return_value = [
+            "/wrong/lib/python3.x/site-packages",
+            "/other/lib/python3.x/site-packages",
+        ]
+        self.mock_site.getusersitepackages.return_value = "/home/user/.local/lib/python3.x/site-packages"
+
+        # not found
+        with patch("pathlib.Path.glob", side_effect=[iter([]), iter([]), iter([])]), self.assertWarns(UserWarning):
+            from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
+
+            assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix: use the built-in `site` package  to get  the correct `site-packages` directory

Related [Issue and Comment](https://github.com/tablegpt/tablegpt-agent/issues/166#issuecomment-2548097990)

On Debian systems, Python installed via a package manager places pip-installed packages in the `dist-packages` directory instead of `site-packages`.

**Code Optimize:**
- Use The python built-in `site` package can correctly identify the appropriate `site-packages` directory, including `dist-packages`
- Unitest Optimization