### PR TITLE
Fix: Use `sysconfig.get_path` to correctly retrieve the Python directory across platforms

### DIFF
--- a/src/tablegpt/__init__.py
+++ b/src/tablegpt/__init__.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-import site
+import sysconfig
 import warnings
 from pathlib import Path
 
 
-def _find_tablegpt_ipykernel_profile_dir(path):
-    possible_installation_location = Path(path).parents[2]
-    possible_profile_dir = Path(possible_installation_location, "share", "ipykernel", "profile", "tablegpt")
+def _find_tablegpt_ipykernel_profile_dir():
+    # https://docs.python.org/3.11/library/sysconfig.html#sysconfig.get_path
+    # https://docs.python.org/3.11/library/sysconfig.html#user-scheme
+    _py_root = Path(sysconfig.get_path("data"))
+
+    possible_profile_dir = Path(_py_root, "share", "ipykernel", "profile", "tablegpt")
 
     _startup_folder = Path(possible_profile_dir, "startup")
     try:
@@ -17,17 +20,10 @@ def _find_tablegpt_ipykernel_profile_dir(path):
         return
 
 
-try:
-    DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR: str | None = next(
-        path
-        for path in map(_find_tablegpt_ipykernel_profile_dir, [*site.getsitepackages(), site.getusersitepackages()])
-        if path is not None
-    )
+DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR: str | None = _find_tablegpt_ipykernel_profile_dir()
 
-except StopIteration:
-    # Means not found.
+if DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR is None:
     msg = """Unable to find tablegpt ipykernel. If you need to use a local kernel,
 please use `pip install -U tablegpt-agent[local]` to install the necessary dependencies.
 For more issues, please submit an issue to us https://github.com/tablegpt/tablegpt-agent/issues."""
     warnings.warn(msg, stacklevel=2)
-    DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR = None

--- a/tests/test_profile_init.py
+++ b/tests/test_profile_init.py
@@ -13,13 +13,13 @@ class TestTableGPTInit(unittest.TestCase):
             del sys.modules["tablegpt"]
 
         # Create a mock site module
-        self.mock_site = MagicMock()
-        self.original_site = sys.modules["site"]
-        sys.modules["site"] = self.mock_site
+        self.mock_sysconfig = MagicMock()
+        self.original_sysconfig = sys.modules["sysconfig"]
+        sys.modules["sysconfig"] = self.mock_sysconfig
 
     def tearDown(self):
         # Restore the original modules
-        sys.modules["site"] = self.original_site
+        sys.modules["sysconfig"] = self.original_sysconfig
 
         # Restore the original tablegpt module if it existed
         if self.original_tablegpt:
@@ -29,38 +29,19 @@ class TestTableGPTInit(unittest.TestCase):
 
     def test_find_tablegpt_ipykernel_profile_dir_found(self):
         # mock return values
-        self.mock_site.getsitepackages.return_value = ["/usr/local/lib/python3.x/site-packages"]
-        self.mock_site.getusersitepackages.return_value = ""
+        self.mock_sysconfig.get_path.return_value = "/usr/local"
 
         with patch("pathlib.Path.glob", return_value=iter(["mock-udfs.py"])):
             from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
 
             assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR == "/usr/local/share/ipykernel/profile/tablegpt"
 
-    def test_default_tablegpt_ipykernel_profile_dir_found_second_path(self):
-        # mock return values
-        self.mock_site.getsitepackages.return_value = [
-            "/wrong/lib/python3.x/site-packages",
-            "/usr/local/lib/python3.x/site-packages",
-        ]
-        self.mock_site.getusersitepackages.return_value = "/home/user/.local/lib/python3.x/site-packages"
-
-        # Found in the second possible path.
-        with patch("pathlib.Path.glob", side_effect=[iter([]), iter(["mock-udfs.py"]), iter([])]):
-            from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
-
-            assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR == "/usr/local/share/ipykernel/profile/tablegpt"
-
     def test_default_tablegpt_ipykernel_profile_dir_not_found(self):
         # mock return values
-        self.mock_site.getsitepackages.return_value = [
-            "/wrong/lib/python3.x/site-packages",
-            "/other/lib/python3.x/site-packages",
-        ]
-        self.mock_site.getusersitepackages.return_value = "/home/user/.local/lib/python3.x/site-packages"
+        self.mock_sysconfig.get_path.return_value = "/wrong/lib/python3.x/site-packages"
 
         # not found
-        with patch("pathlib.Path.glob", side_effect=[iter([]), iter([]), iter([])]), self.assertWarns(UserWarning):
+        with patch("pathlib.Path.glob", return_value=iter([])), self.assertWarns(UserWarning):
             from tablegpt import DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR
 
             assert DEFAULT_TABLEGPT_IPYKERNEL_PROFILE_DIR is None


### PR DESCRIPTION
The issue https://github.com/tablegpt/tablegpt-agent/issues/209 lies in the code that detects ipykernel-related files. It first retrieves the `site-packages` directory and then moves up three levels to the parent directory to reach the Python environment directory.

This approach works correctly on Linux/macOS systems, where the path could be something like `xxx/.venv/lib/python3.x/site-packages`. However, on Windows systems, the path to `site-packages` is typically `xxx/.venv/Lib/site-packages`, which causes the code to fail in correctly detecting the IPython profile.

This PR uses `sysconfig.get_path` to retrieve the Python root directory in a cross-platform manner, eliminating the strong dependency on directory hierarchy.